### PR TITLE
Fix CIDR Update issue

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -65,7 +65,7 @@ func (ctlr *Controller) runController() {
 				break
 			}
 
-			ipAddr := ctlr.Manager.GetIPAddress(req.HostName)
+			ipAddr := ctlr.Manager.GetIPAddress(req.CIDR, req.HostName)
 			if ipAddr != "" {
 				go sendResponse(req, ipAddr)
 				break
@@ -78,7 +78,7 @@ func (ctlr *Controller) runController() {
 				go sendResponse(req, ipAddr)
 			}
 		case ipamspec.DELETE:
-			ipAddr := ctlr.Manager.GetIPAddress(req.HostName)
+			ipAddr := ctlr.Manager.GetIPAddress(req.CIDR, req.HostName)
 			if ipAddr != "" {
 				ctlr.Manager.ReleaseIPAddress(ipAddr)
 				ctlr.Manager.DeleteARecord(req.HostName, ipAddr)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -12,7 +12,7 @@ type Manager interface {
 	// Deletes an A record and releases the IP address
 	DeleteARecord(hostname, ipAddr string)
 	// Gets IP Address associated with hostname
-	GetIPAddress(hostname string) string
+	GetIPAddress(cidr, hostname string) string
 	// Gets and reserves the next available IP address
 	GetNextIPAddress(cidr string) string
 	// Allocates this particular ip from the CIDR


### PR DESCRIPTION
Issue: FIC is not allocating an IP from request CIDR for a host, if the host already has an IP address in another CIDR, during CIDR migration for multiple VirtualServers

Solution: Allocate IP address for hostname though the same hostname already has an IP address if CIDR is different

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>